### PR TITLE
Remove user-select for text and text-size-adjust.

### DIFF
--- a/app/assets/stylesheets/scaffold.css.scss
+++ b/app/assets/stylesheets/scaffold.css.scss
@@ -6,8 +6,6 @@ html, body {
     color: #000000;
 	width: 100%;
 	height: 100%;
-    -webkit-user-select: none;
-    -webkit-text-size-adjust: none;
 }
 div {padding:0px; margin:0px;}
 a{color: #e55302;}


### PR DESCRIPTION
Fixes #10 

Not sure why text-select: none was ever in there. 
Text-size-adjust may have played a role with earlier mobile browsers but shouldn't be needed.